### PR TITLE
fix: add workaround to fix terragrunt's get_repo_root() function handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ if [ -n "$EXIT_CODE" ]; then
   driftive_args="$driftive_args --exit-code=${EXIT_CODE:-false}"
 fi
 
-# Terragrunt get_repo_root() workaround
+# Terragrunt get_repo_root() workaround. Without this, terragrunt will fail with "fatal: detected dubious ownership in repository at ..."
 git config --global --add safe.directory "*"
 
 driftive $driftive_args

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,4 +60,7 @@ if [ -n "$EXIT_CODE" ]; then
   driftive_args="$driftive_args --exit-code=${EXIT_CODE:-false}"
 fi
 
+# Terragrunt get_repo_root() workaround
+git config --global --add safe.directory "*"
+
 driftive $driftive_args

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,11 @@ if [ -n "$TERRAGRUNT_VERSION" ]; then
     echo "Terragrunt could not be found"
     exit 1
   fi
+
+  # Terragrunt get_repo_root() workaround.
+  # Without this, terragrunt will fail with "fatal: detected dubious ownership in repository at ..."
+  git config --global --add safe.directory "*"
+
 fi
 
 driftive_args=" --repo-path=./"
@@ -59,8 +64,5 @@ fi
 if [ -n "$EXIT_CODE" ]; then
   driftive_args="$driftive_args --exit-code=${EXIT_CODE:-false}"
 fi
-
-# Terragrunt get_repo_root() workaround. Without this, terragrunt will fail with "fatal: detected dubious ownership in repository at ..."
-git config --global --add safe.directory "*"
 
 driftive $driftive_args


### PR DESCRIPTION
This pull request includes a workaround for an issue with Terragrunt in the `entrypoint.sh` script. The change ensures that Terragrunt does not fail due to dubious ownership detection in the repository.

* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R35-R39): Added a global Git configuration to mark all directories as safe to avoid Terragrunt failure with "fatal: detected dubious ownership in repository at ..."